### PR TITLE
Do not override application/json parser in OAuth2

### DIFF
--- a/lib/omniauth-tiktok-oauth2/version.rb
+++ b/lib/omniauth-tiktok-oauth2/version.rb
@@ -1,3 +1,3 @@
 module OmniAuthTiktokOauth2
-  VERSION = '0.1.4'
+  VERSION = '0.1.5'
 end

--- a/lib/omniauth/strategies/tiktok_oauth2.rb
+++ b/lib/omniauth/strategies/tiktok_oauth2.rb
@@ -1,8 +1,8 @@
 require 'oauth2'
 require 'omniauth/strategies/oauth2'
 
-OAuth2::Response.register_parser(:tiktok, ['application/json']) do |body|
-  JSON.parse(body)['data']
+OAuth2::Response.register_parser(:tiktok, []) do |body|
+  JSON.parse(body).fetch('data') rescue body
 end
 
 module OmniAuth


### PR DESCRIPTION
Release version 0.1.5

We should not register the parser for any content types since it causes the [default json parser in oauth2](https://github.com/oauth-xx/oauth2/blob/cb8eca28ec8b831833199cb4e60014cfc0bc4ac0/lib/oauth2/response.rb#L21) to be overridden, see https://github.com/oauth-xx/oauth2/blob/cb8eca28ec8b831833199cb4e60014cfc0bc4ac0/lib/oauth2/response.rb#L35-L37.
This can cause problems for other ominauth strategies, such as omniauth-google-oauth2, which use the default json parser.

We only need to register the parser by the `:tiktok` symbol as that's how it's referenced in this gem.