### PR TITLE
[v0.1.6] Migrate to new TikTok domain

### DIFF
--- a/lib/omniauth-tiktok-oauth2/version.rb
+++ b/lib/omniauth-tiktok-oauth2/version.rb
@@ -1,3 +1,3 @@
 module OmniAuthTiktokOauth2
-  VERSION = '0.1.5'
+  VERSION = '0.1.6'
 end

--- a/lib/omniauth/strategies/tiktok_oauth2.rb
+++ b/lib/omniauth/strategies/tiktok_oauth2.rb
@@ -8,12 +8,12 @@ end
 module OmniAuth
   module Strategies
     class TiktokOauth2 < OmniAuth::Strategies::OAuth2
-      USER_INFO_URL = 'https://ads.tiktok.com/open_api/v1.2/user/info/'
+      USER_INFO_URL = 'https://business-api.tiktok.com/open_api/v1.2/user/info/'
       option :name, "tiktok_oauth2"
       option :client_options,
-             site: 'https://ads.tiktok.com',
+             site: 'https://business-api.tiktok.com',
              authorize_url: 'https://ads.tiktok.com/marketing_api/auth',
-             token_url: 'https://ads.tiktok.com/open_api/v1.2/oauth2/access_token'
+             token_url: 'https://business-api.tiktok.com/open_api/v1.2/oauth2/access_token'
 
       option :pkce, true
 


### PR DESCRIPTION
#5 pointed out that TikTok is migrating over their API to a new domain (`business-api.tiktok.com`). The old domain (`ads.tiktok.com`) will stop working on September 30th. For more information, see https://ads.tiktok.com/marketing_api/docs?rid=esb88xalm6m&id=1709207085043713.

This replaces `ads.tiktok.com` with `business-api.tiktok.com` in all API URLs.
resolves #5 