### PR TITLE
Fix callback error

### DIFF
--- a/lib/omniauth/strategies/tiktok_oauth2.rb
+++ b/lib/omniauth/strategies/tiktok_oauth2.rb
@@ -11,9 +11,9 @@ module OmniAuth
       USER_INFO_URL = 'https://business-api.tiktok.com/open_api/v1.2/user/info/'
       option :name, "tiktok_oauth2"
       option :client_options,
-             site: 'https://business-api.tiktok.com',
-             authorize_url: 'https://ads.tiktok.com/marketing_api/auth',
-             token_url: 'https://business-api.tiktok.com/open_api/v1.2/oauth2/access_token'
+             site: 'https://business-api.tiktok.com/',
+             authorize_url: 'https://ads.tiktok.com/marketing_api/auth/',
+             token_url: 'https://business-api.tiktok.com/open_api/v1.2/oauth2/access_token/'
 
       option :pkce, true
 
@@ -49,7 +49,7 @@ module OmniAuth
         options.token_params.merge(
           app_id: options.client_id,
           secret: options.client_secret,
-          auth_code: request.params["code"],
+          auth_code: request.params["auth_code"],
           parse: :tiktok,
         )
       end


### PR DESCRIPTION
There was an issue requesting the token during the callback phase with OmniAuth, this has been fixed.

The fix is in the `authorize_url: 'https://ads.tiktok.com/marketing_api/auth/` by adding a `/` at the end. Without it there was some redirection issues (since tiktok redirects to the new domain). And for some reason just using the new domain `business-api` instead of `ads` doesn't work.

`code` was changed into `auth_code` since that is what the Tiktok developer page recommends (even though they provide both on the callback).