### PR TITLE
Migrate to TikTok API v1.3

### DIFF
--- a/lib/omniauth/strategies/tiktok_oauth2.rb
+++ b/lib/omniauth/strategies/tiktok_oauth2.rb
@@ -8,12 +8,12 @@ end
 module OmniAuth
   module Strategies
     class TiktokOauth2 < OmniAuth::Strategies::OAuth2
-      USER_INFO_URL = 'https://business-api.tiktok.com/open_api/v1.2/user/info/'
+      USER_INFO_URL = 'https://business-api.tiktok.com/open_api/v1.3/user/info/'
       option :name, "tiktok_oauth2"
       option :client_options,
              site: 'https://business-api.tiktok.com/',
              authorize_url: 'https://ads.tiktok.com/marketing_api/auth/',
-             token_url: 'https://business-api.tiktok.com/open_api/v1.2/oauth2/access_token/'
+             token_url: 'https://business-api.tiktok.com/open_api/v1.3/oauth2/access_token/'
 
       option :pkce, true
 
@@ -62,6 +62,17 @@ module OmniAuth
         {
           'Access-Token' => access_token.token,
         }
+      end
+
+      def build_access_token
+        client.auth_code.get_token(
+          request.params['code'],
+          {
+            redirect_uri: callback_url,
+            headers: {'Content-Type' => 'application/json'},
+          }.merge(token_params.to_hash(symbolize_keys: true)),
+          deep_symbolize(options.auth_token_params)
+        )
       end
     end
   end

--- a/omniauth-tiktok-oauth2.gemspec
+++ b/omniauth-tiktok-oauth2.gemspec
@@ -12,6 +12,6 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split("\n")
   gem.require_paths = ['lib']
 
-  gem.add_runtime_dependency 'omniauth-oauth2', '~> 1.6'
-  gem.add_runtime_dependency 'oauth2', '~> 1.1'
+  gem.add_runtime_dependency 'omniauth-oauth2', '~> 1.8'
+  gem.add_runtime_dependency 'oauth2', '>= 2.0.7'
 end


### PR DESCRIPTION
V1.2 of the TikTok Business API will be deprecated on Aug 15, 2023. See https://ads.tiktok.com/marketing_api/docs?id=1740579480076290.

It doesn't sound like any of the changes to the access token endpoint would affect this gem, but apparently it now becomes unhappy if you don't send the token request body as JSON.

Version 2.0.7 of the OAuth2 gem supports this if you set the "Content-Type" header to "application/json", see https://gitlab.com/oauth-xx/oauth2/-/issues/431.

Unfortunately you can't just pass headers in the `token_params` method because the `build_access_token` deep symbolizes all parameters, and the OAuth2 gem expects the headers to be strings. See https://github.com/omniauth/omniauth-oauth2/blob/3a43234ab5dd36a75f9c125c58fcfe1a37b26805/lib/omniauth/strategies/oauth2.rb#L126, and note that the `token_params` is a `Hashie::Mash`.

This means we have to override the `build_access_token` method to avoid the "Content-Type" string getting turned into a symbol.

Fixes https://github.com/burtcorp/omniauth-tiktok-oauth2/issues/9.