### PR TITLE
TikTok API v1.3 changed `id` to `core_user_id`

### DIFF
--- a/lib/omniauth/strategies/tiktok_oauth2.rb
+++ b/lib/omniauth/strategies/tiktok_oauth2.rb
@@ -23,7 +23,7 @@ module OmniAuth
         end
       end
 
-      uid{ raw_info['id'] }
+      uid{ raw_info['core_user_id'] }
 
       info do
         {


### PR DESCRIPTION
TikTok API v1.3 changed the /user/info response to contain the user id as `core_user_id` rather than `uid`.

Fixes #12.
